### PR TITLE
qtbase: eglfs: remove noeglfs flags for wayland

### DIFF
--- a/meta-sdk/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/meta-sdk/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -39,8 +39,7 @@ QT_CONFIG_FLAGS_APPEND_imxpxp = "-no-eglfs"
 QT_CONFIG_FLAGS_APPEND_imxgpu2d = "-no-eglfs -no-opengl -linuxfb"
 QT_CONFIG_FLAGS_APPEND_imxgpu3d = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '-no-eglfs', \
-        bb.utils.contains('DISTRO_FEATURES', 'wayland', '-no-eglfs', \
-            '-eglfs', d), d)}"
+            '-eglfs', d)}"
 QT_CONFIG_FLAGS_append = " ${QT_CONFIG_FLAGS_APPEND}"
 
 QT_CONFIG_FLAGS_MX8_GPU     = ""


### PR DESCRIPTION
remove -noeglfs config flag to support eglfs for wayland.

This patch enables eglfs platform support.

JIRA: https://jira.alm.mentorg.com/browse/SB-15149