### PR TITLE
meta-bsp/layer.conf: Remove imx-m4 related packages.

### DIFF
--- a/meta-bsp/conf/layer.conf
+++ b/meta-bsp/conf/layer.conf
@@ -201,12 +201,6 @@ KERNEL_DEVICETREE_remove_imx7ulpevk = " \
 # OPTEE_BIN_EXT = "8mm"
 MACHINE_FEATURES_remove_imx8mmevk = "qca6174"
 MACHINE_FEATURES_append_imx8mmevk = " bcm43455 bcm4356 bcm4359 jailhouse"
-WKS_FILE_DEPENDS_append_imx8mmevk = " imx-m4-demos"
-IMAGE_BOOT_FILES_append_imx8mmevk = " imx8mm_m4_TCM_hello_world.bin \
-                    imx8mm_m4_TCM_rpmsg_lite_pingpong_rtos_linux_remote.bin \
-                    imx8mm_m4_TCM_rpmsg_lite_str_echo_rtos.bin \
-                    imx8mm_m4_TCM_sai_low_power_audio.bin \
-"
 KERNEL_DEVICETREE_imx8mmevk = " \
     freescale/imx8mm-evk.dtb \
     freescale/imx8mm-evk-ak4497.dtb \


### PR DESCRIPTION
* imx-m4 realted packages are defined in meta-sdk. We don't
  need that layer for mel BSPs neither we need m4 demos.
  So remove the packages.

Signed-off-by: ahsann <noor_ahsan@mentor.com>