### PR TITLE
layer.conf: remove imx-m7-demos

### DIFF
--- a/meta-bsp/conf/layer.conf
+++ b/meta-bsp/conf/layer.conf
@@ -89,7 +89,6 @@ MACHINE_EXTRA_RRECOMMENDS_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'n
 MACHINE_EXTRA_RRECOMMENDS_append_mx7ulp = " imx-m4-demos"
 MACHINE_EXTRA_RRECOMMENDS_append_mx8dxl  = " imx-m4-demos"
 MACHINE_EXTRA_RRECOMMENDS_append_mx8mm  = " imx-m4-demos"
-MACHINE_EXTRA_RRECOMMENDS_append_mx8mn  = " imx-m7-demos"
 MACHINE_EXTRA_RRECOMMENDS_append_mx8mp  = " imx-m7-demos"
 MACHINE_EXTRA_RRECOMMENDS_append_mx8mq  = " imx-m4-demos"
 MACHINE_EXTRA_RRECOMMENDS_append_mx8qm  = " imx-m4-demos"


### PR DESCRIPTION
As MEL doesn't support MCore demos, removing imx-m7-demos for
imx8mnano platform.

Signed-off-by: Arulpandiyan Vadivel <arulpandiyan_vadivel@mentor.com>