### PR TITLE
optee-client.imx.inc: use python3native instead of pythonnative

### DIFF
--- a/meta-bsp/recipes-security/optee-imx/optee-client.imx.inc
+++ b/meta-bsp/recipes-security/optee-imx/optee-client.imx.inc
@@ -5,7 +5,7 @@ HOMEPAGE = "http://www.optee.org/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 
-inherit pythonnative systemd
+inherit python3native systemd
 
 OPTEE_CLIENT_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-client.git;protocol=https"
 SRC_URI = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH}"


### PR DESCRIPTION
pythonnative was deprecated and does not exist anymore.

JIRA: SB-18494

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>