### PR TITLE
opengl-es-cts.inc: use features_check instead of distro_features_check

### DIFF
--- a/meta-sdk/recipes-graphics/vk-gl-cts/opengl-es-cts.inc
+++ b/meta-sdk/recipes-graphics/vk-gl-cts/opengl-es-cts.inc
@@ -13,7 +13,7 @@ VKGLCTS_SRC ?= "git://source.codeaurora.org/external/imx/vk-gl-cts-imx.git;proto
 SRC_URI = "${VKGLCTS_SRC};name=vk-gl-cts;branch=imx-${BP}"
 S = "${WORKDIR}/git"
 
-inherit pkgconfig cmake distro_features_check
+inherit pkgconfig cmake features_check
 
 ANY_OF_DISTRO_FEATURES = "x11 wayland"
 


### PR DESCRIPTION
distro_features_check is deprecated.

Fixes:
WARNING: meta-sdk/recipes-graphics/vk-gl-cts/opengl-es-cts_3.2.4.0.bb:
  distro_features_check.bbclass is deprecated,
  please use features_check.bbclass instead
WARNING: meta-sdk/recipes-graphics/vk-gl-cts/opengl-es-cts_3.2.6.1.bb:
  distro_features_check.bbclass is deprecated,
  please use features_check.bbclass instead

JIRA: SB-18494

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>